### PR TITLE
[UPDATED] changed cam radius for more consistent results, percent_den…

### DIFF
--- a/generation/configs/text_mv.yaml
+++ b/generation/configs/text_mv.yaml
@@ -43,7 +43,7 @@ anneal_timestep: True
 # training iterations for stage 2
 iters_refine: 50
 # training camera radius
-radius: 5.0 #2.5
+radius: 3.5 #2.5
 # training camera fovy
 fovy: 49.1
 # training camera min elevation
@@ -65,7 +65,7 @@ H: 800
 W: 800
 
 ### Gaussian splatting
-num_pts: 8000
+num_pts: 5000
 sh_degree: 0
 position_lr_init: 0.001
 position_lr_final: 0.00002
@@ -75,7 +75,7 @@ feature_lr: 0.01
 opacity_lr: 0.05
 scaling_lr: 0.005
 rotation_lr: 0.005
-percent_dense: 0.01
+percent_dense: 0.015 # 0.01
 density_start_iter: 0
 density_end_iter: 3000
 densification_interval: 50


### PR DESCRIPTION
changed:
"radius" dropped down to 3.5 -> smaller model size; good balance quality - model completion
"num_pts" dropped back to 5000 as it does not affect the final quality of the splat
"percent_dense" slightly increase, reduce the amount of points in the final model, size of the file should be smaller.